### PR TITLE
Filter key events to only handle Press on Windows

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use std::time::Duration;
 
 use crate::app::{ActiveModal, App, DiscoveryState, FocusPanel, MessageTab};
@@ -9,6 +9,12 @@ use crate::client::models::EntityType;
 pub fn handle_events(app: &mut App) -> anyhow::Result<bool> {
     if event::poll(Duration::from_millis(100))? {
         if let Event::Key(key) = event::read()? {
+            // On Windows, crossterm emits both Press and Release events.
+            // Only handle Press to avoid processing each keystroke twice.
+            if key.kind != KeyEventKind::Press {
+                return Ok(app.running);
+            }
+
             // If a background operation is running, Esc cancels it
             if app.bg_running && key.code == KeyCode::Esc {
                 app.cancel_bg();


### PR DESCRIPTION
Fixes #1

On Windows, crossterm emits both `KeyEventKind::Press` and `KeyEventKind::Release` events for every keystroke (and sometimes `Repeat`). Without filtering, each keypress is processed twice — causing duplicate characters in text inputs and double-fired shortcuts.

This adds an early return in `handle_events()` that skips any key event that isn't `KeyEventKind::Press`. This is a no-op on Unix/macOS (where crossterm only emits `Press` by default).