### PR TITLE
Add single message delete from messages panel (x key)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -22,6 +22,10 @@ pub enum BgEvent {
         deleted: u32,
         was_dlq: bool,
     },
+    SingleDeleteComplete {
+        sequence_number: i64,
+        is_dlq: bool,
+    },
     Cancelled {
         message: String,
     },
@@ -111,6 +115,11 @@ pub enum ActiveModal {
         count: u32,
         is_dlq: bool,
         is_topic: bool,
+    },
+    ConfirmSingleDelete {
+        entity_path: String,
+        sequence_number: i64,
+        is_dlq: bool,
     },
     PeekCountInput,
     EditResend,

--- a/src/event.rs
+++ b/src/event.rs
@@ -399,6 +399,44 @@ fn handle_message_input(app: &mut App, key: KeyEvent) {
                 }
             }
         }
+        // x = Delete single selected message
+        KeyCode::Char('x') => {
+            if !block_if_bg_running(app, BG_BUSY_MSG) {
+                let is_dlq = app.message_tab == MessageTab::DeadLetter;
+                let msg = if app.selected_message_detail.is_some() {
+                    app.selected_message_detail.clone()
+                } else {
+                    let msgs = if is_dlq {
+                        &app.dlq_messages
+                    } else {
+                        &app.messages
+                    };
+                    msgs.get(app.message_selected).cloned()
+                };
+                if let Some(msg) = msg {
+                    if let Some(seq) = msg.broker_properties.sequence_number {
+                        if let Some((path, _)) = app.selected_entity() {
+                            let entity_path = if is_dlq {
+                                msg.source_entity
+                                    .clone()
+                                    .unwrap_or_else(|| path.to_string())
+                            } else {
+                                path.to_string()
+                            };
+                            app.modal = ActiveModal::ConfirmSingleDelete {
+                                entity_path,
+                                sequence_number: seq,
+                                is_dlq,
+                            };
+                        }
+                    } else {
+                        app.set_status("Message has no sequence number");
+                    }
+                } else {
+                    app.set_status("No message selected");
+                }
+            }
+        }
         // e = Edit & resend selected message
         KeyCode::Char('e') => {
             if app.selected_message_detail.is_some() {

--- a/src/event_modal.rs
+++ b/src/event_modal.rs
@@ -195,6 +195,15 @@ pub fn handle_modal_input(app: &mut App, key: KeyEvent) {
             }
             _ => {}
         },
+        ActiveModal::ConfirmSingleDelete { .. } => match key.code {
+            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                app.set_status("Deleting message...");
+            }
+            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                app.modal = ActiveModal::None;
+            }
+            _ => {}
+        },
         ActiveModal::PeekCountInput => match key.code {
             KeyCode::Enter => {
                 if let Ok(count) = app.input_buffer.trim().parse::<i32>() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,36 @@ async fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> anyho
                     app.bg_running = false;
                     needs_refresh = true;
                 }
+                BgEvent::SingleDeleteComplete {
+                    sequence_number,
+                    is_dlq,
+                } => {
+                    if is_dlq {
+                        app.dlq_messages.retain(|m| {
+                            m.broker_properties.sequence_number != Some(sequence_number)
+                        });
+                    } else {
+                        app.messages.retain(|m| {
+                            m.broker_properties.sequence_number != Some(sequence_number)
+                        });
+                    }
+                    if app.selected_message_detail.as_ref().is_some_and(|m| {
+                        m.broker_properties.sequence_number == Some(sequence_number)
+                    }) {
+                        app.selected_message_detail = None;
+                    }
+                    let len = if is_dlq {
+                        app.dlq_messages.len()
+                    } else {
+                        app.messages.len()
+                    };
+                    if app.message_selected >= len && len > 0 {
+                        app.message_selected = len - 1;
+                    }
+                    app.set_status(format!("Deleted message seq #{}", sequence_number));
+                    app.bg_running = false;
+                    needs_refresh = true;
+                }
                 BgEvent::Cancelled { message } => {
                     app.set_status(message);
                     app.bg_running = false;
@@ -1181,6 +1211,103 @@ async fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> anyho
                         });
                     }
                 });
+            }
+        }
+
+        // Single message delete (messages panel x key)
+        if app.status_message == "Deleting message..."
+            && app.data_plane.is_some()
+            && !app.bg_running
+        {
+            if let ActiveModal::ConfirmSingleDelete {
+                ref entity_path,
+                sequence_number,
+                is_dlq,
+            } = app.modal
+            {
+                let dp = app.data_plane.clone().unwrap();
+                let path = entity_path.clone();
+                let seq = sequence_number;
+                let tx = app.bg_tx.clone();
+
+                app.bg_running = true;
+                app.modal = ActiveModal::None;
+                app.set_status("Deleting message...");
+
+                if is_dlq {
+                    tokio::spawn(async move {
+                        match dp.remove_from_dlq(&path, seq).await {
+                            Ok(true) => {
+                                let _ = tx.send(BgEvent::SingleDeleteComplete {
+                                    sequence_number: seq,
+                                    is_dlq: true,
+                                });
+                            }
+                            Ok(false) => {
+                                send_failed(&tx, format!("Message seq #{} not found in DLQ", seq));
+                            }
+                            Err(e) => {
+                                send_failed_with(&tx, "Delete failed", e);
+                            }
+                        }
+                    });
+                } else {
+                    tokio::spawn(async move {
+                        // For non-DLQ: peek-lock messages looking for the sequence number
+                        let mut abandoned_uris: Vec<String> = Vec::new();
+                        let max_attempts = 50u32;
+                        let mut found = false;
+
+                        for _ in 0..max_attempts {
+                            match dp.peek_lock(&path, 1).await {
+                                Ok(Some(msg)) => {
+                                    let lock_uri = match msg.lock_token_uri {
+                                        Some(ref uri) => uri.clone(),
+                                        None => continue,
+                                    };
+                                    if msg.broker_properties.sequence_number == Some(seq) {
+                                        match dp.complete_message(&lock_uri).await {
+                                            Ok(_) => found = true,
+                                            Err(e) => {
+                                                for uri in &abandoned_uris {
+                                                    let _ = dp.abandon_message(uri).await;
+                                                }
+                                                send_failed_with(&tx, "Delete failed", e);
+                                                return;
+                                            }
+                                        }
+                                        for uri in &abandoned_uris {
+                                            let _ = dp.abandon_message(uri).await;
+                                        }
+                                        break;
+                                    } else {
+                                        abandoned_uris.push(lock_uri);
+                                    }
+                                }
+                                Ok(None) => break,
+                                Err(e) => {
+                                    for uri in &abandoned_uris {
+                                        let _ = dp.abandon_message(uri).await;
+                                    }
+                                    send_failed_with(&tx, "Delete failed", e);
+                                    return;
+                                }
+                            }
+                        }
+
+                        if !found {
+                            for uri in &abandoned_uris {
+                                let _ = dp.abandon_message(uri).await;
+                            }
+                            send_failed(&tx, format!("Message seq #{} not found", seq));
+                        } else {
+                            let _ = tx.send(BgEvent::SingleDeleteComplete {
+                                sequence_number: seq,
+                                is_dlq: false,
+                            });
+                        }
+                    });
+                }
             }
         }
     }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -64,6 +64,7 @@ pub fn render_help(frame: &mut Frame) {
             "                 (on topics: fan-out across all subs)",
             Style::default().fg(Color::DarkGray),
         )),
+        Line::from("  x              Delete selected message"),
         Line::from("  e              Edit & resend (inline WYSIWYG)"),
         Line::from(vec![
             Span::styled("  C       ", Style::default().fg(Color::Yellow)),

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -99,6 +99,22 @@ pub fn render_modal(frame: &mut Frame, app: &mut App) {
                 Color::Red,
             );
         }
+        ActiveModal::ConfirmSingleDelete {
+            entity_path,
+            sequence_number,
+            is_dlq,
+        } => {
+            let target = if *is_dlq { "DLQ" } else { "queue" };
+            render_confirm_bulk(
+                frame,
+                "Delete Message",
+                &format!(
+                    "Delete message seq #{} from {} of '{}'?\nThis cannot be undone.",
+                    sequence_number, target, entity_path
+                ),
+                Color::Red,
+            );
+        }
         ActiveModal::PeekCountInput => render_peek_count_input(frame, app),
         ActiveModal::ClearOptions { entity_path, .. } => {
             render_clear_options(frame, entity_path);


### PR DESCRIPTION
Delete individual messages from the messages panel using `x`. Shows a confirmation dialog with sequence number and entity path before deleting.

- DLQ messages: uses `remove_from_dlq` directly by sequence number
- Active messages: peek-locks messages sequentially to find the target by sequence number, completes it, and abandons all others
- Removes the deleted message from the local list and adjusts selection
- Help overlay updated with the new keybinding

Closes #5